### PR TITLE
fix: enable vertical scrolling for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
             --accent-yellow: #facc15;
             --accent-yellow-hover: #fde047;
         }
-        html, body { height: 100%; overflow: hidden; }
+        html, body { height: 100%; overflow-x: hidden; overflow-y: auto; }
         body { font-family: 'Inter', sans-serif; background-color: var(--bg-primary); color: var(--text-primary); }
         
         #sidebar { background-color: var(--bg-secondary); border-right: 1px solid var(--border-color); transition: transform 0.3s ease-in-out; z-index: 50; }


### PR DESCRIPTION
## Summary
- allow vertical scrolling by default to improve mobile usability

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b738e6d4508330b795c7ce22287408