### PR TITLE
Implement Vista-style sidebar widgets

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,6 +101,22 @@
 
     <div id="sidebar" class="fixed top-0 left-0 h-full w-72 bg-slate-900/80 backdrop-blur-lg p-4 transform -translate-x-full md:translate-x-0 flex flex-col">
         <h1 class="text-2xl font-bold mb-6 text-yellow-300">Dashboard Pro</h1>
+        <div id="sidebar-widgets" class="space-y-4 mb-6">
+            <div id="clock-widget" class="widget p-4 rounded-lg flex justify-center">
+                <canvas id="clock-canvas" width="150" height="150"></canvas>
+            </div>
+            <div id="slideshow-widget" class="widget rounded-lg overflow-hidden">
+                <img id="slideshow-img" class="w-full h-32 object-cover" src="https://source.unsplash.com/random/200x150?sig=1" alt="slideshow">
+            </div>
+            <div id="cpu-widget" class="widget p-4 rounded-lg text-center">
+                <canvas id="cpu-canvas" width="120" height="60"></canvas>
+                <div class="text-sm mt-2">CPU Usage</div>
+            </div>
+            <div id="calendar-widget" class="widget p-4 rounded-lg text-center">
+                <div id="calendar-header" class="font-semibold mb-2"></div>
+                <div id="calendar-grid" class="grid grid-cols-7 gap-1 text-xs"></div>
+            </div>
+        </div>
         <h2 class="text-sm font-semibold text-slate-400 mb-2 uppercase">Tools</h2>
         <div id="sidebar-tools" class="flex-grow overflow-y-auto space-y-4">
             <!-- Sidebar tools will be injected here -->
@@ -193,6 +209,154 @@ document.addEventListener('DOMContentLoaded', () => {
         { id: 'calculator', name: 'Calculator' },
         { id: 'custom-html', name: 'Custom HTML' },
     ];
+
+    const initSidebarWidgets = () => {
+        const clockCanvas = document.getElementById('clock-canvas');
+        if (clockCanvas) {
+            const ctx = clockCanvas.getContext('2d');
+            let radius = clockCanvas.height / 2;
+            ctx.translate(radius, radius);
+            radius *= 0.9;
+            const drawClock = () => {
+                ctx.clearRect(-clockCanvas.width, -clockCanvas.height, clockCanvas.width * 2, clockCanvas.height * 2);
+                drawFace();
+                drawNumbers();
+                drawTime();
+            };
+            const drawFace = () => {
+                ctx.beginPath();
+                ctx.arc(0, 0, radius, 0, 2 * Math.PI);
+                ctx.fillStyle = 'rgba(0,0,0,0)';
+                ctx.fill();
+                ctx.lineWidth = 4;
+                ctx.strokeStyle = 'rgba(255,255,255,0.2)';
+                ctx.stroke();
+            };
+            const drawNumbers = () => {
+                ctx.font = radius * 0.15 + 'px sans-serif';
+                ctx.textBaseline = 'middle';
+                ctx.textAlign = 'center';
+                for (let num = 1; num <= 12; num++) {
+                    const ang = num * Math.PI / 6;
+                    ctx.rotate(ang);
+                    ctx.translate(0, -radius * 0.8);
+                    ctx.rotate(-ang);
+                    ctx.fillStyle = '#fff';
+                    ctx.fillText(num.toString(), 0, 0);
+                    ctx.rotate(ang);
+                    ctx.translate(0, radius * 0.8);
+                    ctx.rotate(-ang);
+                }
+            };
+            const drawHand = (pos, length, width, color = '#fff') => {
+                ctx.beginPath();
+                ctx.lineWidth = width;
+                ctx.lineCap = 'round';
+                ctx.strokeStyle = color;
+                ctx.moveTo(0, 0);
+                ctx.rotate(pos);
+                ctx.lineTo(0, -length);
+                ctx.stroke();
+                ctx.rotate(-pos);
+            };
+            const drawTime = () => {
+                const now = new Date();
+                let hour = now.getHours();
+                let minute = now.getMinutes();
+                let second = now.getSeconds();
+                hour = hour % 12;
+                hour = (hour * Math.PI / 6) + (minute * Math.PI / (6 * 60)) + (second * Math.PI / (360 * 60));
+                drawHand(hour, radius * 0.5, 6);
+                minute = (minute * Math.PI / 30) + (second * Math.PI / (30 * 60));
+                drawHand(minute, radius * 0.8, 4);
+                second = second * Math.PI / 30;
+                drawHand(second, radius * 0.9, 2, '#facc15');
+            };
+            setInterval(drawClock, 1000);
+            drawClock();
+        }
+
+        const slideImg = document.getElementById('slideshow-img');
+        if (slideImg) {
+            const images = [
+                'https://source.unsplash.com/random/200x150?sig=1',
+                'https://source.unsplash.com/random/200x150?sig=2',
+                'https://source.unsplash.com/random/200x150?sig=3',
+                'https://source.unsplash.com/random/200x150?sig=4'
+            ];
+            let idx = 0;
+            setInterval(() => {
+                idx = (idx + 1) % images.length;
+                slideImg.src = images[idx];
+            }, 5000);
+        }
+
+        const cpuCanvas = document.getElementById('cpu-canvas');
+        if (cpuCanvas) {
+            const ctx = cpuCanvas.getContext('2d');
+            const drawCPU = () => {
+                ctx.clearRect(0, 0, cpuCanvas.width, cpuCanvas.height);
+                const usages = [Math.random(), Math.random()];
+                usages.forEach((u, i) => {
+                    const x = 30 + i * 60;
+                    const r = 25;
+                    ctx.beginPath();
+                    ctx.arc(x, 30, r, 0, 2 * Math.PI);
+                    ctx.strokeStyle = 'rgba(255,255,255,0.2)';
+                    ctx.lineWidth = 4;
+                    ctx.stroke();
+                    ctx.beginPath();
+                    ctx.arc(x, 30, r, -Math.PI / 2, (u * 2 * Math.PI) - Math.PI / 2);
+                    ctx.strokeStyle = '#facc15';
+                    ctx.lineWidth = 4;
+                    ctx.stroke();
+                    ctx.fillStyle = '#fff';
+                    ctx.font = '12px Inter';
+                    ctx.textAlign = 'center';
+                    ctx.textBaseline = 'middle';
+                    ctx.fillText(Math.round(u * 100) + '%', x, 30);
+                });
+            };
+            drawCPU();
+            setInterval(drawCPU, 2000);
+        }
+
+        const calendarHeader = document.getElementById('calendar-header');
+        const calendarGrid = document.getElementById('calendar-grid');
+        if (calendarHeader && calendarGrid) {
+            const renderCalendar = () => {
+                const now = new Date();
+                const year = now.getFullYear();
+                const month = now.getMonth();
+                calendarHeader.textContent = now.toLocaleString('default', { month: 'long', year: 'numeric' });
+                calendarGrid.innerHTML = '';
+                const weekdays = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+                weekdays.forEach(d => {
+                    const div = document.createElement('div');
+                    div.textContent = d;
+                    div.className = 'font-bold text-center';
+                    calendarGrid.appendChild(div);
+                });
+                const firstDay = new Date(year, month, 1).getDay();
+                const daysInMonth = new Date(year, month + 1, 0).getDate();
+                for (let i = 0; i < firstDay; i++) {
+                    const empty = document.createElement('div');
+                    empty.className = 'text-center';
+                    calendarGrid.appendChild(empty);
+                }
+                for (let d = 1; d <= daysInMonth; d++) {
+                    const cell = document.createElement('div');
+                    cell.textContent = d;
+                    cell.className = 'text-center';
+                    if (d === now.getDate()) {
+                        cell.classList.add('bg-yellow-400', 'text-black', 'rounded');
+                    }
+                    calendarGrid.appendChild(cell);
+                }
+            };
+            renderCalendar();
+        }
+    };
 
     // --- Core Dashboard Logic ---
     const dashboardModule = (() => {
@@ -811,6 +975,7 @@ document.addEventListener('DOMContentLoaded', () => {
     } };
 
     // --- Initialize Dashboard ---
+    initSidebarWidgets();
     dashboardModule.init();
 });
 </script>


### PR DESCRIPTION
## Summary
- Add Vista-inspired sidebar with widgets for clock, slideshow, CPU meter, and calendar
- Initialize widgets alongside existing tools for a more corporate dashboard feel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7656ae8c483308292d9efcaef96a8